### PR TITLE
Error metric: Tuples to remove

### DIFF
--- a/pysrc/errors/tuples_to_remove.py
+++ b/pysrc/errors/tuples_to_remove.py
@@ -7,8 +7,11 @@ from ..models import metanome_run
 
 def tuples_to_remove(*, baseline_config: 'metanome_run.MetanomeRunConfiguration', experiment: 'metanome_run.MetanomeRun') -> None:
     """Get, for every IND, the absolute and relative numbers of tuples that have to be removed from the baseline such that this IND is valid.
-    This adds TuplesToRemove to the errors list of each IND"""
+    This adds TuplesToRemove to the errors list of each IND, if it not exists"""
     for ind in experiment.results.inds:
+        # If there already exists a TuplesToRemove entry, ignore this IND
+        if next((error for error in ind.errors if isinstance(error, TuplesToRemove)), None) is not None:
+            continue
         # If we already know this is a TP, we don't have to check it (no tuples have to be removed)
         if next((error.ind_type for error in ind.errors if isinstance(error, INDType)), None) == 'TP':
             result = TuplesToRemove(0, 0)

--- a/pysrc/errors/tuples_to_remove.py
+++ b/pysrc/errors/tuples_to_remove.py
@@ -8,37 +8,45 @@ def tuples_to_remove(*, baseline_config: 'metanome_run.MetanomeRunConfiguration'
     result: dict[IND, int] = {}
     for ind in experiment.results.inds:
         # Format: (file_path, column_name)
-        dependents_files: list[tuple[str, str]] = []
+        dependent_files: list[tuple[str, str]] = []
         for dependant in ind.dependents:
             dependant_name = dependant.table_name.split('__')[0]
             file_path = next(file for file in baseline_config.source_files if dependant_name in file)
-            dependents_files.append((file_path, dependant.column_name))
+            dependent_files.append((file_path, dependant.column_name))
         referenced_files: list[tuple[str, str]] = []
         for referenced in ind.referenced:
             referenced_name = referenced.table_name.split('__')[0]
             file_path = next(file for file in baseline_config.source_files if referenced_name in file)
             referenced_files.append((file_path, referenced.column_name))
-        dependent_entries_to_remove = 0
         file_contents: dict[str, list[list[str]]] = {}
-        for file in itertools.chain(dependents_files, referenced_files):
+        for file in itertools.chain(dependent_files, referenced_files):
             if file[0] in file_contents:
                 continue
             with open(file[0], 'r') as file_handle:
-                print(f'Read from file {file[0]}')
                 reader = csv.reader(file_handle, delimiter=';')
                 data = list(reader)
                 file_contents[file[0]] = data
-        for pair in zip(dependents_files, referenced_files):
-            dependant_column = int(pair[0][1][6:]) - 1  # This is 1-based from BINDER
-            dependent_data: list[str] = [line[dependant_column] for line in file_contents[pair[0][0]]]
-            referenced_column = int(pair[1][1][6:]) - 1  # This is 1-based from BINDER
-            referenced_data: list[str] = [line[referenced_column] for line in file_contents[pair[1][0]]]
-            dependent_entries_to_remove += check_tuple_pair(dependent_data=dependent_data, referenced_data=referenced_data)
+        dependent_data = data_from_files(dependent_files, file_contents)
+        referenced_data = data_from_files(referenced_files, file_contents)
+        dependent_entries_to_remove = check_tuple_pair(dependent_data=dependent_data, referenced_data=referenced_data)
         result[ind] = dependent_entries_to_remove
     return result
 
 
-def check_tuple_pair(*, dependent_data: list[str], referenced_data: list[str]) -> int:
+def data_from_files(files: list[tuple[str, str]], file_contents: dict[str, list[list[str]]]) -> list[tuple[str,  ...]]:
+    data_list: list[list[str]] = [
+        [
+            line[int(file[1][6:]) - 1]
+            for line
+            in file_contents[file[0]]
+        ]
+        for file
+        in files]
+    data: list[tuple[str,  ...]] = [entry for entry in zip(*data_list)]
+    return data
+
+
+def check_tuple_pair(*, dependent_data: list[tuple[str, ...]], referenced_data: list[tuple[str, ...]]) -> int:
     dependent_set = set(dependent_data)
     referenced_set = set(referenced_data)
     difference = dependent_set - referenced_set

--- a/pysrc/errors/tuples_to_remove.py
+++ b/pysrc/errors/tuples_to_remove.py
@@ -1,45 +1,46 @@
 import csv
-from models.ind import IND
-from models.metanome_run import MetanomeRun, MetanomeRunConfiguration
+import itertools
+from ..models.ind import IND
+from ..models import metanome_run
 
 
-def tuples_to_remove(*, baseline_config: MetanomeRunConfiguration, experiment: MetanomeRun) -> dict[IND, int]:
+def tuples_to_remove(*, baseline_config: 'metanome_run.MetanomeRunConfiguration', experiment: 'metanome_run.MetanomeRun') -> dict[IND, int]:
     result: dict[IND, int] = {}
     for ind in experiment.results.inds:
         # Format: (file_path, column_name)
         dependents_files: list[tuple[str, str]] = []
         for dependant in ind.dependents:
-            dependant_name = dependant.table_name.split('_')[0]
+            dependant_name = dependant.table_name.split('__')[0]
             file_path = next(file for file in baseline_config.source_files if dependant_name in file)
             dependents_files.append((file_path, dependant.column_name))
         referenced_files: list[tuple[str, str]] = []
         for referenced in ind.referenced:
-            referenced_name = referenced.table_name.split('_')[0]
+            referenced_name = referenced.table_name.split('__')[0]
             file_path = next(file for file in baseline_config.source_files if referenced_name in file)
             referenced_files.append((file_path, referenced.column_name))
         dependent_entries_to_remove = 0
+        file_contents: dict[str, list[list[str]]] = {}
+        for file in itertools.chain(dependents_files, referenced_files):
+            if file[0] in file_contents:
+                continue
+            with open(file[0], 'r') as file_handle:
+                print(f'Read from file {file[0]}')
+                reader = csv.reader(file_handle, delimiter=';')
+                data = list(reader)
+                file_contents[file[0]] = data
         for pair in zip(dependents_files, referenced_files):
-            dependent_data: list[str]
-            with open(pair[0][0], 'r') as dependent_file:
-                reader = csv.reader(dependent_file, delimiter=';')
-                dependant_column = int(pair[0][1][6:]) - 1  # This is 1-based from BINDER
-                data = list(reader)
-                dependent_data = [line[dependant_column] for line in data]
-            referenced_data: list[str]
-            with open(pair[0][0], 'r') as referenced_file:
-                reader = csv.reader(referenced_file, delimiter=';')
-                dependant_column = int(pair[0][1][6:]) - 1  # This is 1-based from BINDER
-                data = list(reader)
-                referenced_data = [line[dependant_column] for line in data]
+            dependant_column = int(pair[0][1][6:]) - 1  # This is 1-based from BINDER
+            dependent_data: list[str] = [line[dependant_column] for line in file_contents[pair[0][0]]]
+            referenced_column = int(pair[1][1][6:]) - 1  # This is 1-based from BINDER
+            referenced_data: list[str] = [line[referenced_column] for line in file_contents[pair[1][0]]]
             dependent_entries_to_remove += check_tuple_pair(dependent_data=dependent_data, referenced_data=referenced_data)
         result[ind] = dependent_entries_to_remove
-    return result   
+    return result
 
 
 def check_tuple_pair(*, dependent_data: list[str], referenced_data: list[str]) -> int:
-    dependent_values_to_remove = 0
-    for dependant_value in dependent_data:
-        if dependant_value not in referenced_data:
-            dependent_values_to_remove += 1
-    return dependent_values_to_remove
+    dependent_set = set(dependent_data)
+    referenced_set = set(referenced_data)
+    difference = dependent_set - referenced_set
+    return len([dependent for dependent in dependent_data if dependent != '' and dependent in difference])
             

--- a/pysrc/errors/tuples_to_remove.py
+++ b/pysrc/errors/tuples_to_remove.py
@@ -1,7 +1,7 @@
 import csv
 import itertools
 
-from pysrc.models.errors import TuplesToRemove
+from pysrc.models.errors import INDType, TuplesToRemove
 from ..models import metanome_run
 
 
@@ -9,6 +9,11 @@ def tuples_to_remove(*, baseline_config: 'metanome_run.MetanomeRunConfiguration'
     """Get, for every IND, the absolute and relative numbers of tuples that have to be removed from the baseline such that this IND is valid.
     This adds TuplesToRemove to the errors list of each IND"""
     for ind in experiment.results.inds:
+        # If we already know this is a TP, we don't have to check it (no tuples have to be removed)
+        if next((error.ind_type for error in ind.errors if isinstance(error, INDType)), None) == 'TP':
+            result = TuplesToRemove(0, 0)
+            ind.errors.append(result)
+            continue
         # Format: (file_path, column_name)
         dependent_files: list[tuple[str, str]] = []
         for dependant in ind.dependents:

--- a/pysrc/errors/tuples_to_remove.py
+++ b/pysrc/errors/tuples_to_remove.py
@@ -4,8 +4,9 @@ from ..models.ind import IND
 from ..models import metanome_run
 
 
-def tuples_to_remove(*, baseline_config: 'metanome_run.MetanomeRunConfiguration', experiment: 'metanome_run.MetanomeRun') -> dict[IND, int]:
-    result: dict[IND, int] = {}
+def tuples_to_remove(*, baseline_config: 'metanome_run.MetanomeRunConfiguration', experiment: 'metanome_run.MetanomeRun') -> dict[IND, tuple[int, float]]:
+    """Get, for every IND, the absolute and relative numbers of tuples that have to be removed from the baseline such that this IND is valid"""
+    result: dict[IND, tuple[int, float]] = {}
     for ind in experiment.results.inds:
         # Format: (file_path, column_name)
         dependent_files: list[tuple[str, str]] = []
@@ -29,7 +30,7 @@ def tuples_to_remove(*, baseline_config: 'metanome_run.MetanomeRunConfiguration'
         dependent_data = data_from_files(dependent_files, file_contents)
         referenced_data = data_from_files(referenced_files, file_contents)
         dependent_entries_to_remove = check_tuple_pair(dependent_data=dependent_data, referenced_data=referenced_data)
-        result[ind] = dependent_entries_to_remove
+        result[ind] = (dependent_entries_to_remove, dependent_entries_to_remove / len(dependent_data))
     return result
 
 

--- a/pysrc/models/errors.py
+++ b/pysrc/models/errors.py
@@ -11,6 +11,8 @@ class ErrorMetric(ABC):
 class TuplesToRemove(ErrorMetric):
     absolute_tuples_to_remove: int
     relative_tuples_to_remove: float
+    absolute_distinct_tuples_to_remove: int
+    relative_distinct_tuples_to_remove: float
 
 
 @dataclass(frozen=True)

--- a/pysrc/models/errors.py
+++ b/pysrc/models/errors.py
@@ -1,0 +1,12 @@
+from abc import ABC
+from dataclasses import dataclass
+
+
+class ErrorMetric(ABC):
+    pass
+
+
+@dataclass(frozen=True)
+class TuplesToRemove(ErrorMetric):
+    absolute_tuples_to_remove: int
+    relative_tuples_to_remove: float

--- a/pysrc/models/errors.py
+++ b/pysrc/models/errors.py
@@ -1,5 +1,6 @@
 from abc import ABC
 from dataclasses import dataclass
+from typing import Literal
 
 
 class ErrorMetric(ABC):
@@ -10,3 +11,8 @@ class ErrorMetric(ABC):
 class TuplesToRemove(ErrorMetric):
     absolute_tuples_to_remove: int
     relative_tuples_to_remove: float
+
+
+@dataclass(frozen=True)
+class INDType(ErrorMetric):
+    ind_type: Literal['TP', 'FP']

--- a/pysrc/models/ind.py
+++ b/pysrc/models/ind.py
@@ -1,6 +1,7 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from pysrc.models.column_information import ColumnInformation
+from pysrc.models.errors import ErrorMetric
 
 
 @dataclass(frozen=True)
@@ -9,6 +10,8 @@ class IND:
     dependents: list[ColumnInformation]
 
     referenced: list[ColumnInformation]
+
+    errors: list[ErrorMetric] = field(default_factory=list, compare=False)
 
     def __repr__(self) -> str:
         return f'{" & ".join(str(d) for d in self.dependents)} [= {" & ".join(str(r) for r in self.referenced)}'

--- a/pysrc/models/metanome_run.py
+++ b/pysrc/models/metanome_run.py
@@ -125,6 +125,7 @@ class MetanomeRunBatch:
                 in sublist
                 if isinstance(error, TuplesToRemove)
             ]
+            # Consider whether a mean is appropriate here (also consider sum or other metrics)
             avg_abs_total = statistics.fmean([error.absolute_tuples_to_remove for error in tuples_to_remove_errors])
             avg_rel_total = statistics.fmean([error.relative_tuples_to_remove for error in tuples_to_remove_errors])
             avg_abs_uniq = statistics.fmean([error.absolute_distinct_tuples_to_remove for error in tuples_to_remove_errors])

--- a/pysrc/models/metanome_run.py
+++ b/pysrc/models/metanome_run.py
@@ -108,14 +108,15 @@ class MetanomeRunBatch:
     def baseline(self) -> MetanomeRun:
         return next(run for run in self.runs if run.configuration.is_baseline)
     
-    def tuples_to_remove(self) -> dict[MetanomeRun, float]:
-        """Returns the average number of rows to remove such that false positive INDs become real"""
+    def tuples_to_remove(self) -> dict[MetanomeRun, tuple[float, float]]:
+        """Returns the average number (absolute & relative) of rows to remove such that false positive INDs become real"""
         baseline = self.baseline
-        results: dict[MetanomeRun, float] = {}
+        results: dict[MetanomeRun, tuple[float, float]] = {}
         for run in self.runs:
-            run_results: dict[IND, int] = tuples_to_remove.tuples_to_remove(baseline_config=baseline.configuration, experiment=run)
-            avg = statistics.fmean([value for value in run_results.values()])
-            results[run] = avg
+            run_results: dict[IND, tuple[int, float]] = tuples_to_remove.tuples_to_remove(baseline_config=baseline.configuration, experiment=run)
+            avg_abs = statistics.fmean([value[0] for value in run_results.values()])
+            avg_rel = statistics.fmean([value[1] for value in run_results.values()])
+            results[run] = (avg_abs, avg_rel)
         return results
 
 

--- a/pysrc/models/metanome_run.py
+++ b/pysrc/models/metanome_run.py
@@ -109,10 +109,11 @@ class MetanomeRunBatch:
     def baseline(self) -> MetanomeRun:
         return next(run for run in self.runs if run.configuration.is_baseline)
     
-    def tuples_to_remove(self) -> dict[MetanomeRun, tuple[float, float]]:
-        """Returns the average number (absolute & relative) of rows to remove such that false positive INDs become real"""
+    def tuples_to_remove(self) -> dict[MetanomeRun, tuple[float, float, float, float]]:
+        """Returns the average number (absolute & relative) of rows (total & unique) to remove such that false positive INDs become real
+        The form of a dict entry is (absolute_total, relative_total, absolute_distinct, relative_distinct)"""
         baseline = self.baseline
-        results: dict[MetanomeRun, tuple[float, float]] = {}
+        results: dict[MetanomeRun, tuple[float, float, float, float]] = {}
         for run in self.runs:
             tuples_to_remove.tuples_to_remove(baseline_config=baseline.configuration, experiment=run)
             run_results: dict[IND, list[ErrorMetric]] = {ind: ind.errors for ind in run.results.inds}
@@ -124,9 +125,11 @@ class MetanomeRunBatch:
                 in sublist
                 if isinstance(error, TuplesToRemove)
             ]
-            avg_abs = statistics.fmean([error.absolute_tuples_to_remove for error in tuples_to_remove_errors])
-            avg_rel = statistics.fmean([error.relative_tuples_to_remove for error in tuples_to_remove_errors])
-            results[run] = (avg_abs, avg_rel)
+            avg_abs_total = statistics.fmean([error.absolute_tuples_to_remove for error in tuples_to_remove_errors])
+            avg_rel_total = statistics.fmean([error.relative_tuples_to_remove for error in tuples_to_remove_errors])
+            avg_abs_uniq = statistics.fmean([error.absolute_distinct_tuples_to_remove for error in tuples_to_remove_errors])
+            avg_rel_uniq = statistics.fmean([error.relative_distinct_tuples_to_remove for error in tuples_to_remove_errors])
+            results[run] = (avg_abs_total, avg_rel_total, avg_abs_uniq, avg_rel_uniq)
         return results
 
 

--- a/pysrc/models/metanome_run.py
+++ b/pysrc/models/metanome_run.py
@@ -126,6 +126,8 @@ class MetanomeRunBatch:
                 if isinstance(error, TuplesToRemove)
             ]
             # Consider whether a mean is appropriate here (also consider sum or other metrics)
+            # Also consider that unique tuples to be removed may overlap between INDs.
+            # However, it might get expensive to keep all unique tuples in memory and check every entry against it.
             avg_abs_total = statistics.fmean([error.absolute_tuples_to_remove for error in tuples_to_remove_errors])
             avg_rel_total = statistics.fmean([error.relative_tuples_to_remove for error in tuples_to_remove_errors])
             avg_abs_uniq = statistics.fmean([error.absolute_distinct_tuples_to_remove for error in tuples_to_remove_errors])

--- a/pysrc/models/metanome_run.py
+++ b/pysrc/models/metanome_run.py
@@ -7,7 +7,7 @@ from typing import Iterator
 from pysrc.errors import tuples_to_remove
 
 from pysrc.models.column_information import ColumnInformation
-from pysrc.models.errors import ErrorMetric, TuplesToRemove
+from pysrc.models.errors import ErrorMetric, INDType, TuplesToRemove
 from pysrc.models.ind import IND
 
 
@@ -247,9 +247,10 @@ def run_as_compared_csv_line(run: MetanomeRun, baseline: MetanomeRunResults) -> 
 
     for ind in inds:
         if baseline.has_ind(ind):
-        # if ind in baseline.inds:
+            ind.errors.append(INDType('TP'))
             tp += 1
         else:
+            ind.errors.append(INDType('FP'))
             fp += 1
 
     fn = len(baseline.inds) - tp

--- a/pysrc/scripts/evaluation.py
+++ b/pysrc/scripts/evaluation.py
@@ -110,7 +110,7 @@ def collect_error_metrics(experiments: MetanomeRunBatch, mode: Literal['interact
     if mode == 'interactive':
         print('### Tuples To Remove ###')
         print('When looking into the shown file combinations, on average that many tuples have to be removed to make all found INDs TPs.')
-        print('The data is presented as (absolute number of tuples to be removed, relative percentage of tuples to be removed).')
+        print('The data is presented as (absolute number of tuples to be removed, relative percentage of tuples to be removed, absolute number of distinct tuples to be removed, relative percentage of distinct tuples to be removed).')
         print({
             tuple([
                 file.rsplit('/', 1)[1]

--- a/pysrc/scripts/evaluation.py
+++ b/pysrc/scripts/evaluation.py
@@ -119,6 +119,7 @@ def run_evaluation(config: GlobalConfiguration, args: argparse.Namespace) -> Opt
     csv_path = create_evaluation_csv(experiments, config.output_file, config)
     if config.create_plots:
         plot_path = make_plots(config.output_file, config.plot_folder, config)
+    print(experiments.tuples_to_remove())
     match args.return_path:
         case 'csv':
             return csv_path

--- a/pysrc/scripts/evaluation.py
+++ b/pysrc/scripts/evaluation.py
@@ -2,14 +2,14 @@ import argparse
 import csv
 import json
 import os
-from typing import Optional
+from typing import Literal, Optional
 from dacite import from_dict
 
 import matplotlib.pyplot as plt
 import pandas as pd
 import seaborn as sns
 
-from pysrc.utils.enhanced_json_encoder import EnhancedJSONDecoder
+from pysrc.utils.enhanced_json_encoder import EnhancedJSONDecoder, EnhancedJSONEncoder
 
 from ..configuration import GlobalConfiguration
 from ..models.metanome_run import (MetanomeRun, MetanomeRunBatch,
@@ -105,10 +105,37 @@ def make_plots(output_file: str, plot_folder: str, config: GlobalConfiguration) 
     return plot_path
 
 
+def collect_error_metrics(experiments: MetanomeRunBatch, mode: Literal['interactive', 'file'], config: GlobalConfiguration, output_file: str) -> str:
+    tuples_to_remove = experiments.tuples_to_remove()
+    if mode == 'interactive':
+        print('### Tuples To Remove ###')
+        print('When looking into the shown file combinations, on average that many tuples have to be removed to make all found INDs TPs.')
+        print('The data is presented as (absolute number of tuples to be removed, relative percentage of tuples to be removed).')
+        print({
+            tuple([
+                file.rsplit('/', 1)[1]
+                for file
+                in run.configuration.source_files
+            ]): error
+            for run, error
+            in tuples_to_remove.items()
+            if error[0] + error[1] > 0.0
+        })
+    # Always print results in detail to a file
+    output_path = os.path.join(os.getcwd(), config.output_folder, output_file)
+    output_json = f'{output_path}_with_errors.json'
+    with open(output_json, 'w', encoding='utf-8') as json_file:
+        json.dump(experiments, json_file,
+                 ensure_ascii=False, indent=4, cls=EnhancedJSONEncoder)
+    
+    return output_json
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument('--file', type=str, required=True, help='The JSON file containing the experiment information to be evaluated')
-    parser.add_argument('--return-path', type=str, required=False, default=None, help='Whether to return no path (default), the path of the created csv file (`csv`) or of the plot (`plot`)')
+    parser.add_argument('--return-path', type=str, required=False, default=None, help='Whether to return no path (default), the path of the created csv file (`csv`), of the plot (`plot`), or of the error metrics (`error`)')
+    parser.add_argument('--interactive', action=argparse.BooleanOptionalAction, required=False, default=False, help='Whether to print the error metrics in a human-readable way')
     GlobalConfiguration.argparse_arguments(parser)
     args = parser.parse_args()
     return args
@@ -119,12 +146,14 @@ def run_evaluation(config: GlobalConfiguration, args: argparse.Namespace) -> Opt
     csv_path = create_evaluation_csv(experiments, config.output_file, config)
     if config.create_plots:
         plot_path = make_plots(config.output_file, config.plot_folder, config)
-    print(experiments.tuples_to_remove())
+    error_path = collect_error_metrics(experiments, 'interactive' if args.interactive == True else 'file', config, config.output_file)
     match args.return_path:
         case 'csv':
             return csv_path
         case 'plot':
             return plot_path
+        case 'error':
+            return error_path
         case _:
             return None
 

--- a/pysrc/scripts/evaluation.py
+++ b/pysrc/scripts/evaluation.py
@@ -61,7 +61,7 @@ def make_plots(output_file: str, plot_folder: str, config: GlobalConfiguration) 
         df_method,
         x='method',
         hue='type',
-        hue_order=['tp', 'fp'],
+        hue_order=['tp', 'fp', 'fn'],
         multiple='stack',
         ax=ax1,
         linewidth=.3,
@@ -78,8 +78,8 @@ def make_plots(output_file: str, plot_folder: str, config: GlobalConfiguration) 
             d.append([rate,'tp', 1])
         for i in range(int(frame['fp'].mean())):
             d.append([rate,'fp', 1])
-        # for i in range(int(frame['fn'].mean())):
-        #     d.append([rate,'fn', 1])
+        for i in range(int(frame['fn'].mean())):
+            d.append([rate,'fn', 1])
 
     df_rate = pd.DataFrame(d, columns=['rate', 'type', 'count'])
     
@@ -87,7 +87,7 @@ def make_plots(output_file: str, plot_folder: str, config: GlobalConfiguration) 
         df_rate,
         x='rate',
         hue='type',
-        hue_order=['tp', 'fp'],
+        hue_order=['tp', 'fp', 'fn'],
         multiple='stack',
         ax=ax2,
         linewidth=.3,


### PR DESCRIPTION
First draft of an error metric. When testing with actual FPs, this seems to be working. Currently only checked for unary INDs, nary *should* work though.

~~Based on #3~~

We could also add a check for the absolute/relative number of distinct tuple values to remove.

Closes #9 